### PR TITLE
Replace `Once` with `OnceExit` to do the compression last

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const cssoToPostcss = require('./lib/cssoToPostcss.js');
 
 module.exports = (options = {}) => ({
     postcssPlugin: 'postcss-csso',
-    Once(root, { result, postcss }) {
+    OnceExit(root, { result, postcss }) {
         result.root = cssoToPostcss(compress(postcssToCsso(root), options).ast, postcss);
     }
 });


### PR DESCRIPTION
Hi,

With the recent update of `postcss-nested` to use `RuleExit` (https://github.com/postcss/postcss-nested/blob/main/index.js#L135) it seems that `Once` that postcss-csso is fired too early.

Making postcss-csso run before other postcss plugins finish converting the CSS file and thus can't parse the currently  generated CSS.

Using `OnceExit` instead of `Once` moves this processing when everything else is finished.

